### PR TITLE
Ignoring github payloads that do not contain push data

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -27,6 +27,11 @@ exports.control = function(options) {
                     error = true;
                 }
 
+                if (!repoData.error && !repoData.repository) {
+                    webdep.log("Webhook payload was not for a push.");
+                    return;
+                }
+
                 if (!repoData.error) {
 
                     webdep.log("Checking incoming repo " + repoData.repository.url + "...");


### PR DESCRIPTION
When first setting up a github payload, it sends a test webhook that does not include the `repository` key and that was causing webhook-deployer to crash. This catches it and ignores.
